### PR TITLE
modify:ヘッダーとフッターのレスポンシブ対応 #66

### DIFF
--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="flex justify-between items-center py-4 md:py-8 mb-8 md:mb-12 xl:mb-16">
   <%= link_to 'ダッシュボード', admin_root_path, class: 'inline-flex items-center text-black-800 text-2xl md:text-3xl font-bold gap-2.5" aria-label="logo' %>
-  <nav class="hidden lg:flex gap-12">
+  <nav class="lg:flex gap-12">
     <%= link_to 'ログアウト', admin_logout_path, class: 'text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100',  data: { turbo_method: :delete }  %>
   </nav>
 </header>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <header class="flex justify-between items-center py-4 md:py-8 mb-8 md:mb-12 xl:mb-16">
   <%= link_to '誰でもデザイン', root_path, class: 'inline-flex items-center text-black-800 text-2xl md:text-3xl font-bold gap-2.5" aria-label="logo' %>
-  <nav class="hidden lg:flex gap-12">
+  <nav class="lg:flex gap-12">
     <%= link_to '初心者はこちら', for_beginner_path, class: 'text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100' %>
     <%= link_to 'ログイン', login_path, class: 'text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100' %>
   </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="flex justify-between items-center py-4 md:py-8 mb-8 md:mb-12 xl:mb-16">
   <%= link_to '誰でもデザイン', root_path, class: 'inline-flex items-center text-black-800 text-2xl md:text-3xl font-bold gap-2.5" aria-label="logo' %>
-  <nav class="hidden lg:flex gap-12">
+  <nav class="lg:flex gap-12">
     <%= link_to '初心者はこちら', for_beginner_path, class: 'text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100' %>
-    <%= link_to 'ログアウト', logout_path, class: 'text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100', method: :delete %>
+    <%= link_to 'ログアウト', logout_path, class: 'text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100', data: { turbo_method: :delete } %>
   </nav>
 </header>


### PR DESCRIPTION
ヘッダーとフッターのレスポンシブ対応

スマホ画面でもヘッダーとフッターが適切に表示されるよう実装した。