### PR TITLE
modify:ヘッダーのレイアウト調整 #134

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -2,6 +2,7 @@
   <%= link_to '誰でもデザイン', root_path, class: 'inline-flex items-center text-black-800 text-2xl md:text-3xl font-bold gap-2.5" aria-label="logo' %>
   <nav class="text-sm md:text-lg lg:flex gap-12 font-semibold items-center">
     <%= link_to '初心者はこちら', for_beginner_path, class: 'btn bg-green-800 hover:bg-green-700 text-white rounded-lg' %>
+    <%= link_to 'ユーザー登録', new_user_path, class: 'text-gray-500 hover:text-green-800 active:text-green-900' %>
     <%= link_to 'ログイン', login_path, class: 'text-gray-500 hover:text-green-800 active:text-green-900' %>
   </nav>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,9 @@
   <nav class="text-sm md:text-lg lg:flex gap-12 font-semibold items-center">
     <%= link_to '初心者はこちら', for_beginner_path, class: 'btn bg-green-800 hover:bg-green-700 text-white rounded-lg' %>
     <%= link_to '脱・初心者に向けて', growing_path, class: 'btn bg-green-800 hover:bg-green-700 text-white rounded-lg' %>
-    <%= link_to 'お気に入り一覧', likes_design_tips_path, class: 'text-gray-500 hover:text-green-800 active:text-green-900' %>
+    <%= link_to 'お気に入り情報', likes_design_tips_path, class: 'text-gray-500 hover:text-green-800 active:text-green-900' %>
+    <%= link_to '情報リスト', '#', class: 'text-gray-500 hover:text-green-800 active:text-green-900' %>
+    <%= link_to '情報メモ', '#', class: 'text-gray-500 hover:text-green-800 active:text-green-900' %>
     <%= link_to 'ログアウト', logout_path, class: 'text-gray-500 hover:text-green-800 active:text-green-900', data: { turbo_method: :delete } %>
   </nav>
 </header>


### PR DESCRIPTION
ヘッダーのレイアウトを調整した。

ログイン前ヘッダーから遷移できるページ
・初心者はこちら　・ユーザー登録　・ログイン
ログイン後ヘッダーから遷移できるページ
・初心者はこちら　・脱・初心者に向けて　・お気に入り情報　・情報リスト　・情報メモ　・ログアウト