### PR TITLE
Fix desigin tips create and edit #146

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem 'meta-tags'
 
 gem 'dotenv-rails'
 
+gem 'acts-as-taggable-on', '~> 9.0'
+
 
 
 # Use Sass to process CSS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    acts-as-taggable-on (9.0.1)
+      activerecord (>= 6.0, < 7.1)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
@@ -354,6 +356,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 9.0)
   bootsnap
   capybara
   config

--- a/app/controllers/admin/design_tips_controller.rb
+++ b/app/controllers/admin/design_tips_controller.rb
@@ -4,13 +4,13 @@ class Admin::DesignTipsController < Admin::BaseController
   # GET /design_tips or /design_tips.json
   def index
     @design_tips = DesignTip.all
-    @category_list=Category.all
+    @tag_list = DesignTip.tag_counts_on(:tags).most_used(20)
   end
 
   # GET /design_tips/1 or /design_tips/1.json
   def show
     @design_tip = DesignTip.find(params[:id])
-    @design_tip_categories = @design_tip.categories
+    @tag_list = @design_tip.tag_counts_on(:tags)
   end
 
   # GET /design_tips/new
@@ -21,15 +21,12 @@ class Admin::DesignTipsController < Admin::BaseController
   # GET /design_tips/1/edit
   def edit
     @design_tip = DesignTip.find(params[:id])
-    @category_list = @design_tip.categories.pluck(:name).join(',')
   end
 
   # POST /design_tips or /design_tips.json
   def create
     @design_tip = DesignTip.new(design_tip_params)
-    category_list = params[:design_tip][:category].split(',')
     if @design_tip.save
-      @design_tip.save_category(category_list)
       redirect_to admin_design_tip_url(@design_tip), success: t('defaults.message.created', item: DesignTip.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -39,9 +36,7 @@ class Admin::DesignTipsController < Admin::BaseController
   # PATCH/PUT /design_tips/1 or /design_tips/1.json
   def update
     @design_tip = DesignTip.find(params[:id])
-    category_list = params[:design_tip][:category].split(',')
     if @design_tip.update(design_tip_params)
-      @design_tip.save_category(category_list)
       redirect_to admin_design_tip_path(@design_tip), success: t('defaults.message.updated', item: DesignTip.model_name.human)
     else
       render :edit, status: :unprocessable_entity
@@ -71,6 +66,6 @@ class Admin::DesignTipsController < Admin::BaseController
 
   # Only allow a list of trusted parameters through.
   def design_tip_params
-    params.require(:design_tip).permit(:title, :guidance, :url)
+    params.require(:design_tip).permit(:title, :guidance, :url, :tag_list)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,2 @@
 class Category < ApplicationRecord
-  has_many :design_tip_categories,dependent: :destroy, foreign_key: 'category_id'
-  has_many :design_tips,through: :design_tip_categories
-
-  validates :name, uniqueness: true, presence: true
 end

--- a/app/models/design_tip.rb
+++ b/app/models/design_tip.rb
@@ -1,21 +1,4 @@
 class DesignTip < ApplicationRecord
-  belongs_to :user
   has_many :likes, dependent: :destroy
-  has_many :design_tip_categories,dependent: :destroy
-  has_many :categories,through: :design_tip_categories
-
-  def save_category(sent_categories)
-    current_categories = self.categories.pluck(:name) unless self.categories.nil?
-    old_categories = current_categories - sent_categories
-    new_categories = sent_categories - current_categories
-
-    old_categories.each do |old|
-      self.categories.delete Category.find_by(name: old)
-    end
-
-    new_categories.each do |new|
-      new_design_tip_category = Category.find_or_create_by(name: new)
-      self.categories << new_design_tip_category
-    end
-  end
+  acts_as_taggable
 end

--- a/app/models/design_tip_category.rb
+++ b/app/models/design_tip_category.rb
@@ -1,6 +1,2 @@
 class DesignTipCategory < ApplicationRecord
-  belongs_to :design_tip
-  belongs_to :category
-  validates :design_tip_id, presence: true
-  validates :category_id, presence: true
 end

--- a/app/views/admin/design_tips/_design_tip.html.erb
+++ b/app/views/admin/design_tips/_design_tip.html.erb
@@ -15,9 +15,8 @@
   </div>
 
   <div class="my-5">
-    <% design_tip.categories.each do|category| %>
-      <%= link_to category.name, '#', class: 'badge rounded-pill bg-primary'%>
-    <% end %>
+    <strong class="block font-medium mb-1">Tag</strong>
+    <%= render 'tag_list', tag_list: design_tip.tag_list %>
   </div>
 
   <% if action_name != "show" %>

--- a/app/views/admin/design_tips/_form.html.erb
+++ b/app/views/admin/design_tips/_form.html.erb
@@ -27,8 +27,8 @@
   </div>
 
   <div class="my-5">
-    <%= form.label :category %>
-    <%= form.text_field :category, value: @category_list, placeholder: ",で区切って入力してください", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.label :tag_list %>
+    <%= form.text_field :tag_list, value: @design_tip.tag_list.join(','), placeholder: ",で区切って入力してください", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
   <div class="inline">

--- a/app/views/admin/design_tips/_form.html.erb
+++ b/app/views/admin/design_tips/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @design_tip, class: "contents" do |form| %>
+<%= form_with model: @design_tip, url: admin_design_tips_path, class: "contents" do |form| %>
   <% if design_tip.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(design_tip.errors.count, "error") %> prohibited this design_tip from being saved:</h2>

--- a/app/views/admin/design_tips/_tag_list.html.erb
+++ b/app/views/admin/design_tips/_tag_list.html.erb
@@ -1,0 +1,3 @@
+<% tag_list.each do |tag| %>
+  <%= content_tag :span, tag, class: "badge badge-primary mr-1 p-2" %>
+<% end %>

--- a/db/migrate/20230123123607_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230123123607_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20230123123608_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230123123608_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20230123123609_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230123123609_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20230123123610_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230123123610_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20230123123611_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230123123611_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20230123123612_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230123123612_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20230123123613_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230123123613_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 7)
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_21_112746) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_23_123613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,37 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_21_112746) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at", precision: nil
+    t.string "tenant", limit: 128
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index ["tenant"], name: "index_taggings_on_tenant"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "name", null: false
@@ -72,4 +103,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_21_112746) do
   add_foreign_key "design_tip_categories", "design_tips"
   add_foreign_key "likes", "design_tips"
   add_foreign_key "likes", "users"
+  add_foreign_key "taggings", "tags"
 end


### PR DESCRIPTION
## 概要
管理者画面で情報の新規登録、編集できなくなっていたためそれを修正した。
カテゴリーの登録時にバグが発生していたため、それを解決するためgem 'acts-as-taggable-on'を導入し
それに合わせて各ファイルの修正を行なった。

## 実装内容
・情報の登録、編集の際ルーティング先をadmin_design_tips_pathにすべきところがdesign_tips_pathになっていたため
ルーティング先を変更。
・gem 'acts-as-taggable-on'を導入。
・gemの仕様に合わせて実装を行い、情報の登録、編集ができるよう修正。
