### PR TITLE
Add media column for design tip #150

### DIFF
--- a/app/controllers/admin/design_tips_controller.rb
+++ b/app/controllers/admin/design_tips_controller.rb
@@ -66,6 +66,6 @@ class Admin::DesignTipsController < Admin::BaseController
 
   # Only allow a list of trusted parameters through.
   def design_tip_params
-    params.require(:design_tip).permit(:title, :guidance, :url, :tag_list)
+    params.require(:design_tip).permit(:title, :guidance, :url, :medium, :tag_list)
   end
 end

--- a/app/models/design_tip.rb
+++ b/app/models/design_tip.rb
@@ -2,5 +2,5 @@ class DesignTip < ApplicationRecord
   has_many :likes, dependent: :destroy
   acts_as_taggable
 
-  enum media: { web: 0, book: 1, movie: 2 }
+  enum medium: { web: 0, book: 1, movie: 2 }
 end

--- a/app/models/design_tip.rb
+++ b/app/models/design_tip.rb
@@ -1,4 +1,6 @@
 class DesignTip < ApplicationRecord
   has_many :likes, dependent: :destroy
   acts_as_taggable
+
+  enum media: { web: 0, book: 1, movie: 2 }
 end

--- a/app/views/admin/design_tips/_form.html.erb
+++ b/app/views/admin/design_tips/_form.html.erb
@@ -27,6 +27,11 @@
   </div>
 
   <div class="my-5">
+    <%= form.label :medium %>
+    <%= form.select :medium, DesignTip.media.keys.to_a, {}, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+  </div>
+
+  <div class="my-5">
     <%= form.label :tag_list %>
     <%= form.text_field :tag_list, value: @design_tip.tag_list.join(','), placeholder: ",で区切って入力してください", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>

--- a/app/views/design_tips/index.html.erb
+++ b/app/views/design_tips/index.html.erb
@@ -3,10 +3,79 @@
   <%= render 'home/search_form' %>
 </div>
 
-<div class="container pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 mt-20 pb-16">
-  <% if @design_tips.present? %>
-    <%= render @design_tips %>
-  <% else %>
-    <p><%= t('.no_result') %></p>
-  <% end %>
+<div data-controller="view">
+  <div class="flex justify-around pt-20">
+    <a class="tab is-active text-gray-500 hover:text-brown active:text-brown text-2xl lg:text-3xl font-serif text-center mb-4 md:mb-6" aria-current="page" data-view-target="menu" data-action="view#menuClick">Webサイト</a>
+    <a class="tab not-active text-gray-500 hover:text-brown active:text-brown text-2xl lg:text-3xl font-serif text-center mb-4 md:mb-6" data-view-target="menu" data-action="view#menuClick">書籍</a>
+    <a class="tab not-active text-gray-500 hover:text-brown active:text-brown text-2xl lg:text-3xl font-serif text-center mb-4 md:mb-6" data-view-target="menu" data-action="view#menuClick">動画</a>
+  </div>
+
+  <div data-view-target="content" >
+    <div class="container pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 mt-20 pb-16">
+      <% @design_tips.each do |design_tip| %>
+        <% if design_tip.medium == 'web' %>
+          <div class="bg-white flex flex-col md:flex-row items-center border rounded-lg h-full ">
+            <div class="flex flex-col gap-2 p-4 lg:p-6">
+              <div class="text-brown text-xl font-serif font-bold hover:text-yellow-900">
+                <%= link_to design_tip.title, design_tip.url, target: :_blank, rel: "noopener noreferrer" %>
+              </div>
+              <p class="card-text"><%= design_tip.guidance %></p>
+              <div class="my-5">
+                <%= render 'tag_list', tag_list: design_tip.tag_list %>
+              </div>
+              <% if logged_in? %>
+                <%= render 'like_button', design_tip: design_tip %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="hidden" data-view-target="content" >
+    <div class="container pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 mt-20 pb-16">
+      <% @design_tips.each do |design_tip| %>
+        <% if design_tip.medium == 'book' %>
+          <div class="bg-white flex flex-col md:flex-row items-center border rounded-lg h-full ">
+            <div class="flex flex-col gap-2 p-4 lg:p-6">
+              <div class="text-brown text-xl font-serif font-bold hover:text-yellow-900">
+                <%= link_to design_tip.title, design_tip.url, target: :_blank, rel: "noopener noreferrer" %>
+              </div>
+              <p class="card-text"><%= design_tip.guidance %></p>
+              <div class="my-5">
+                <%= render 'tag_list', tag_list: design_tip.tag_list %>
+              </div>
+              <% if logged_in? %>
+                <%= render 'like_button', design_tip: design_tip %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+    <div class="hidden" data-view-target="content" >
+    <div class="container pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 mt-20 pb-16">
+      <% @design_tips.each do |design_tip| %>
+        <% if design_tip.medium == 'movie' %>
+          <div class="bg-white flex flex-col md:flex-row items-center border rounded-lg h-full ">
+            <div class="flex flex-col gap-2 p-4 lg:p-6">
+              <div class="text-brown text-xl font-serif font-bold hover:text-yellow-900">
+                <%= link_to design_tip.title, design_tip.url, target: :_blank, rel: "noopener noreferrer" %>
+              </div>
+              <p class="card-text"><%= design_tip.guidance %></p>
+              <div class="my-5">
+                <%= render 'tag_list', tag_list: design_tip.tag_list %>
+              </div>
+              <% if logged_in? %>
+                <%= render 'like_button', design_tip: design_tip %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/db/migrate/20230124120119_add_media_to_design_tips.rb
+++ b/db/migrate/20230124120119_add_media_to_design_tips.rb
@@ -1,5 +1,0 @@
-class AddMediaToDesignTips < ActiveRecord::Migration[7.0]
-  def change
-    add_column :design_tips, :media, :integer, null: false, default: 0
-  end
-end

--- a/db/migrate/20230124120119_add_media_to_design_tips.rb
+++ b/db/migrate/20230124120119_add_media_to_design_tips.rb
@@ -1,0 +1,5 @@
+class AddMediaToDesignTips < ActiveRecord::Migration[7.0]
+  def change
+    add_column :design_tips, :media, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20230124123547_add_medium_to_design_tips.rb
+++ b/db/migrate/20230124123547_add_medium_to_design_tips.rb
@@ -1,0 +1,5 @@
+class AddMediumToDesignTips < ActiveRecord::Migration[7.0]
+  def change
+    add_column :design_tips, :medium, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_24_120119) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_123547) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,7 +29,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_120119) do
     t.string "url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "media", default: 0, null: false
+    t.integer "medium", default: 0, null: false
   end
 
   create_table "likes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_123613) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_120119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_123613) do
     t.string "url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "media", default: 0, null: false
   end
 
   create_table "likes", force: :cascade do |t|


### PR DESCRIPTION
## 概要
情報一覧ページで情報を媒体別にタグで切り替えて表示できるよう実装した。

## 実装内容
・情報にenumを用いるmediumカラムを追加し、情報を媒体別に管理できるようにした。
・情報の登録、編集時に媒体を選択できるようにした。
・情報一覧ページで媒体ごとにタブを作成し、媒体名をクリックすることで表示が切り替わるよう実装した
