### PR TITLE
add:トップページの情報にタグとお気に入りボタンを表示させる #152

### DIFF
--- a/app/views/design_tips/_like_button.html.erb
+++ b/app/views/design_tips/_like_button.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.like?(design_tip) %>
-  <%= render 'unlike', { design_tip: design_tip } %>
+  <%= render 'design_tips/unlike', { design_tip: design_tip } %>
 <% else %>
-  <%= render 'like', { design_tip: design_tip } %>
+  <%= render 'design_tips/like', { design_tip: design_tip } %>
 <% end %>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -121,6 +121,12 @@
                     <%= link_to design_tip.title, design_tip.url, target: :_blank, rel: "noopener noreferrer" %>
                   </div>
                   <p class="text-gray-500"><%= design_tip.guidance %></p>
+                  <div class="my-5">
+                    <%= render 'design_tips/tag_list', tag_list: design_tip.tag_list %>
+                  </div>
+                  <% if logged_in? %>
+                    <%= render 'design_tips/like_button', design_tip: design_tip %>
+                  <% end %>
                 </div>
               </div>
             <% end %>


### PR DESCRIPTION
## 概要
トップページの情報にタグとお気に入りボタンを表示させた

## 実装内容
design_tips内のタグとお気に入りパーシャルをhome/topで表示させるよう実装した
