### PR TITLE
modify:管理者ログイン画面のレイアウトを変更する #154

### DIFF
--- a/app/views/admin/layouts/admin_login.html.erb
+++ b/app/views/admin/layouts/admin_login.html.erb
@@ -13,7 +13,7 @@
 
   <body>
     <main class="container mx-auto">
-      <%= render 'admin/shared/header' %>
+      <%= link_to '誰でもデザイン', root_path, class: 'font-serif pt-10 inline-flex items-center text-black-800 text-2xl md:text-3xl font-bold gap-2.5" aria-label="logo' %>
       <%= yield %>
       <%= render 'admin/shared/footer' %>
     </main>

--- a/app/views/admin/user_sessions/new.html.erb
+++ b/app/views/admin/user_sessions/new.html.erb
@@ -5,7 +5,7 @@
       <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
         <h1 class="font-bold text-center text-2xl mt-12"><%= t '.title' %></h1>
         <div class="p-12 md:p-18">
-          <%= form_with url: login_path, local: true do |f| %>
+          <%= form_with url: admin_login_path, local: true do |f| %>
             <div class="flex flex-col text-lg mb-6 md:mb-8">
               <%= f.label :email, User.human_attribute_name(:email) %>
               <%= f.email_field :email, class: "w-64 h-12 outline-green-800 rounded-lg" %>


### PR DESCRIPTION
## 概要
管理者ログイン画面のレイアウトを変更した

## 実装内容
管理者ログイン画面のヘッダーを管理者画面の共通ヘッダーからロゴに変更し、一般ユーザー向けのトップページへ
遷移できるよう実装した。
