### PR TITLE
add:情報ジャンルを追加し、トップページに表示させる #176

### DIFF
--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -66,8 +66,8 @@
               </div>
 
               <div>
-                <%= link_to 'UX・UI',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'UX・UI'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">UX・UI</p>
+                <%= link_to 'UI・UX',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'UI・UX'}}, { class: "text-lg md:text-xl font-serif mb-2" } %>
+                <p class="text-gray-500 mb-2">UI・UX</p>
               </div>
             </div>
 
@@ -151,6 +151,28 @@
               <div>
                 <%= link_to 'エンジニア向け',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'エンジニア向け'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
                 <p class="text-gray-500 mb-2">for engineers</p>
+              </div>
+            </div>
+
+            <div class="flex gap-4 md:gap-6">
+              <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown rounded-lg md:rounded-xl shadow-lg">
+                <svg style="width:24px;height:24px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>space-invaders</title><path d="M7,6H5V4H7V6M17,6H19V4H17V6M23,12V18H21V14H19V18H17V16H7V18H5V14H3V18H1V12H3V10H5V8H7V6H9V8H15V6H17V8H19V10H21V12H23M15,10V12H17V10H15M7,12H9V10H7V12M11,18H7V20H11V18M17,18H13V20H17V18Z" /></svg>
+              </div>
+
+              <div>
+                <%= link_to 'お手本',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'お手本'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
+                <p class="text-gray-500 mb-2">example</p>
+              </div>
+            </div>
+
+            <div class="flex gap-4 md:gap-6">
+              <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown rounded-lg md:rounded-xl shadow-lg">
+                <svg style="width:24px;height:24px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>space-invaders</title><path d="M7,6H5V4H7V6M17,6H19V4H17V6M23,12V18H21V14H19V18H17V16H7V18H5V14H3V18H1V12H3V10H5V8H7V6H9V8H15V6H17V8H19V10H21V12H23M15,10V12H17V10H15M7,12H9V10H7V12M11,18H7V20H11V18M17,18H13V20H17V18Z" /></svg>
+              </div>
+
+              <div>
+                <%= link_to 'HTML・CSS',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'HTML・CSS'}}, { class: "text-lg md:text-xl font-serif mb-2" } %>
+                <p class="text-gray-500 mb-2">HTML・CSS</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 概要
情報ジャンルを追加し、トップページに表示させた

## 実装内容
お手本とHTML・CSSの情報ジャンルを追加し、トップページに表示させた
UI・UXのジャンルの見た目の軽微な修正を行った。
