### PR TITLE
Modify top page design tips category #182

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ gem 'google-apis-analyticsreporting_v4', '~> 0.13.0'
 
 gem 'whenever', require: false
 
+gem 'material_icons'
+
 
 
 # Use Sass to process CSS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,8 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    material_icons (4.0.0)
+      railties (>= 3.2)
     matrix (0.4.2)
     memoist (0.16.2)
     meta-tags (2.18.0)
@@ -405,6 +407,7 @@ DEPENDENCIES
   google-apis-analyticsreporting_v4 (~> 0.13.0)
   importmap-rails
   jbuilder
+  material_icons
   meta-tags
   pg (~> 1.1)
   pry-byebug

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,7 @@
  *= require_tree .
  *= require_self
  *= require materialdesignicons
+ *= require material_icons
  */
 
 .tab.is-active{

--- a/app/views/admin/layouts/application.html.erb
+++ b/app/views/admin/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
 
+    <%= stylesheet_link_tag 'https://fonts.googleapis.com/icon?family=Material+Icons', media: 'all' %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -34,145 +34,133 @@
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                  <path fill="currentColor" d="M17.5,12A1.5,1.5 0 0,1 16,10.5A1.5,1.5 0 0,1 17.5,9A1.5,1.5 0 0,1 19,10.5A1.5,1.5 0 0,1 17.5,12M14.5,8A1.5,1.5 0 0,1 13,6.5A1.5,1.5 0 0,1 14.5,5A1.5,1.5 0 0,1 16,6.5A1.5,1.5 0 0,1 14.5,8M9.5,8A1.5,1.5 0 0,1 8,6.5A1.5,1.5 0 0,1 9.5,5A1.5,1.5 0 0,1 11,6.5A1.5,1.5 0 0,1 9.5,8M6.5,12A1.5,1.5 0 0,1 5,10.5A1.5,1.5 0 0,1 6.5,9A1.5,1.5 0 0,1 8,10.5A1.5,1.5 0 0,1 6.5,12M12,3A9,9 0 0,0 3,12A9,9 0 0,0 12,21A1.5,1.5 0 0,0 13.5,19.5C13.5,19.11 13.35,18.76 13.11,18.5C12.88,18.23 12.73,17.88 12.73,17.5A1.5,1.5 0 0,1 14.23,16H16A5,5 0 0,0 21,11C21,6.58 16.97,3 12,3Z" />
-                </svg>
+                <span class="material-icons">palette</span>
               </div>
 
               <div>
-                <%= link_to '配色',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'配色'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">color</p>
+                <%= link_to '配色',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'配色'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">color</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                  <path fill="currentColor" d="M17,8H20V20H21V21H17V20H18V17H14L12.5,20H14V21H10V20H11L17,8M18,9L14.5,16H18V9M5,3H10C11.11,3 12,3.89 12,5V16H9V11H6V16H3V5C3,3.89 3.89,3 5,3M6,5V9H9V5H6Z" />
-                </svg>
+                <span class="material-icons">sort_by_alpha</span>
               </div>
 
               <div>
-                <%= link_to 'フォント',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'フォント'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">font</p>
+                <%= link_to 'フォント',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'フォント'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">font</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                  <path fill="currentColor" d="M20 17C21.1 17 22 16.1 22 15V4C22 2.9 21.1 2 20 2H9.5C9.8 2.6 10 3.3 10 4H20V15H11V17M15 7V9H9V22H7V16H5V22H3V14H1.5V9C1.5 7.9 2.4 7 3.5 7H15M8 4C8 5.1 7.1 6 6 6S4 5.1 4 4 4.9 2 6 2 8 2.9 8 4M17 6H19V14H17V6M14 10H16V14H14V10M11 10H13V14H11V10Z" />
-                </svg>
+                <span class="material-icons">swipe</span>
               </div>
 
               <div>
-                <%= link_to 'UI・UX',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'UI・UX'}}, { class: "text-lg md:text-xl font-serif mb-2" } %>
-                <p class="text-gray-500 mb-2">UI・UX</p>
+                <%= link_to 'UI・UX',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'UI・UX'}}, { class: "text-lg md:text-xl font-serif text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">UI・UX</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                  <path fill="currentColor" d="M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z" />
-                </svg>
+                <span class="material-icons">star_border</span>
               </div>
 
               <div>
-                <%= link_to 'テクニック',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'テクニック'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">technique</p>
+                <%= link_to 'テクニック',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'テクニック'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">technique</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                  <path fill="currentColor" d="M18 13.09C17.47 13.18 16.97 13.34 16.5 13.55V6H18V13.09M12.5 21.5C10.29 21.5 8.5 19.71 8.5 17.5V5C8.5 3.62 9.62 2.5 11 2.5S13.5 3.62 13.5 5V15.5C13.5 16.05 13.05 16.5 12.5 16.5S11.5 16.05 11.5 15.5V6H10V15.5C10 16.88 11.12 18 12.5 18C12.71 18 12.91 17.97 13.1 17.92C13.35 16.58 14.03 15.41 15 14.54V5C15 2.79 13.21 1 11 1S7 2.79 7 5V17.5C7 20.54 9.46 23 12.5 23C13.13 23 13.73 22.89 14.29 22.7C13.97 22.29 13.7 21.84 13.5 21.36C13.17 21.44 12.84 21.5 12.5 21.5M20 18V15H18V18H15V20H18V23H20V20H23V18H20Z" />
-                </svg>
+                <span class="material-icons">attach_file</span>
               </div>
 
               <div>
-                <%= link_to 'テンプレート',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'テンプレート'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">template</p>
+                <%= link_to 'テンプレート',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'テンプレート'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">template</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                  <path fill="currentColor" d="M4,4H11V2H4A2,2 0 0,0 2,4V11H4V4M10,13L6,18H18L15,14L12.97,16.71L10,13M17,8.5A1.5,1.5 0 0,0 15.5,7A1.5,1.5 0 0,0 14,8.5A1.5,1.5 0 0,0 15.5,10A1.5,1.5 0 0,0 17,8.5M20,2H13V4H20V11H22V4A2,2 0 0,0 20,2M20,20H13V22H20A2,2 0 0,0 22,20V13H20V20M4,13H2V20A2,2 0 0,0 4,22H11V20H4V13Z" />
-                </svg>
+                <span class="material-icons">wallpaper</span>
               </div>
 
               <div>
-                <%= link_to 'デザイン例',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'デザイン例'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">example</p>
+                <%= link_to 'デザイン例',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'デザイン例'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">designs</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>account-edit</title><path d="M21.7,13.35L20.7,14.35L18.65,12.3L19.65,11.3C19.86,11.09 20.21,11.09 20.42,11.3L21.7,12.58C21.91,12.79 21.91,13.14 21.7,13.35M12,18.94L18.06,12.88L20.11,14.93L14.06,21H12V18.94M12,14C7.58,14 4,15.79 4,18V20H10V18.11L14,14.11C13.34,14.03 12.67,14 12,14M12,4A4,4 0 0,0 8,8A4,4 0 0,0 12,12A4,4 0 0,0 16,8A4,4 0 0,0 12,4Z" /></svg>
+                <span class="material-icons">school</span>
               </div>
 
               <div>
-                <%= link_to '基礎知識',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'基礎知識'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">basic knowledge</p>
+                <%= link_to '基礎知識',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'基礎知識'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">basic knowledge</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>content-copy</title><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" /></svg>
+                <span class="material-icons">photo_library</span>
               </div>
 
               <div>
-                <%= link_to 'フリー素材',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'フリー素材'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">material</p>
+                <%= link_to 'フリー素材',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'フリー素材'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">material</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
               <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>view-compact</title><path d="M3,19H9V12H3V19M10,19H22V12H10V19M3,5V11H22V5H3Z" /></svg>
+                <span class="material-icons">dashboard</span>
               </div>
 
               <div>
-                <%= link_to 'レイアウト',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'レイアウト'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">layout</p>
+                <%= link_to 'レイアウト',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'レイアウト'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">layout</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
-              <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>space-invaders</title><path d="M7,6H5V4H7V6M17,6H19V4H17V6M23,12V18H21V14H19V18H17V16H7V18H5V14H3V18H1V12H3V10H5V8H7V6H9V8H15V6H17V8H19V10H21V12H23M15,10V12H17V10H15M7,12H9V10H7V12M11,18H7V20H11V18M17,18H13V20H17V18Z" /></svg>
+              <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
+                <span class="material-icons">android</span>
               </div>
 
               <div>
-                <%= link_to 'エンジニア向け',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'エンジニア向け'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">for engineers</p>
+                <%= link_to 'エンジニア向け',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'エンジニア向け'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">for engineers</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
-              <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>space-invaders</title><path d="M7,6H5V4H7V6M17,6H19V4H17V6M23,12V18H21V14H19V18H17V16H7V18H5V14H3V18H1V12H3V10H5V8H7V6H9V8H15V6H17V8H19V10H21V12H23M15,10V12H17V10H15M7,12H9V10H7V12M11,18H7V20H11V18M17,18H13V20H17V18Z" /></svg>
+              <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
+                <span class="material-icons">brush</span>
               </div>
 
               <div>
-                <%= link_to 'お手本',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'お手本'}}, { class: "text-lg md:text-xl font-serif font-semibold mb-2" } %>
-                <p class="text-gray-500 mb-2">example</p>
+                <%= link_to 'お手本',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'お手本'}}, { class: "text-lg md:text-xl font-serif font-semibold text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">example</p>
               </div>
             </div>
 
             <div class="flex gap-4 md:gap-6">
-              <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown rounded-lg md:rounded-xl shadow-lg">
-                <svg style="width:24px;height:24px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>space-invaders</title><path d="M7,6H5V4H7V6M17,6H19V4H17V6M23,12V18H21V14H19V18H17V16H7V18H5V14H3V18H1V12H3V10H5V8H7V6H9V8H15V6H17V8H19V10H21V12H23M15,10V12H17V10H15M7,12H9V10H7V12M11,18H7V20H11V18M17,18H13V20H17V18Z" /></svg>
+              <div class="w-12 md:w-14 h-12 md:h-14 flex justify-center items-center shrink-0 bg-brown text-white rounded-lg md:rounded-xl shadow-lg">
+                <span class="material-icons">subtitles</span>
               </div>
 
               <div>
-                <%= link_to 'HTML・CSS',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'HTML・CSS'}}, { class: "text-lg md:text-xl font-serif mb-2" } %>
-                <p class="text-gray-500 mb-2">HTML・CSS</p>
+                <%= link_to 'HTML・CSS',{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>'HTML・CSS'}}, { class: "text-lg md:text-xl font-serif text-stone-500 hover:text-stone-700 mb-2" } %>
+                <p class="text-gray-400 mb-2">HTML・CSS</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 概要
トップページの情報ジャンルのデザインを修正する

## 実装内容
gem'material icons'を導入しマテリアルアイコンを利用できるようセットアップした
トップページの情報ジャンル欄のデザインを修正した
