### PR TITLE
Modify design tips index #197

### DIFF
--- a/app/views/design_tips/index.html.erb
+++ b/app/views/design_tips/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class='flex justify-center pt-10'>
+<div class='flex pt-10'>
   <%= render 'home/search_form' %>
 </div>
 
@@ -12,16 +12,16 @@
 <hr>
 
 <% if params[:q].present? && params[:q][:tags_name_cont].present? %>
-  <div class='text-gray-500 text-2xl lg:text-3xl font-serif pt-10'>
+  <div class='text-gray-600 text-2xl font-serif pt-10'>
     <%= params[:q][:tags_name_cont] %>の情報一覧
   </div>
 <% end %>
 
 <div data-controller="view">
   <div class="flex justify-around pt-20">
-    <a class="tab is-active text-gray-500 hover:text-brown active:text-brown text-2xl lg:text-3xl font-serif mb-4 md:mb-6" aria-current="page" data-view-target="menu" data-action="view#menuClick">Webサイト</a>
-    <a class="tab not-active text-gray-500 hover:text-brown active:text-brown text-2xl lg:text-3xl font-serif mb-4 md:mb-6" data-view-target="menu" data-action="view#menuClick">書籍</a>
-    <a class="tab not-active text-gray-500 hover:text-brown active:text-brown text-2xl lg:text-3xl font-serif mb-4 md:mb-6" data-view-target="menu" data-action="view#menuClick">動画</a>
+    <a class="tab is-active text-gray-500 hover:text-brown active:text-brown text-2xl font-serif mb-4 md:mb-6" aria-current="page" data-view-target="menu" data-action="view#menuClick">Webサイト</a>
+    <a class="tab not-active text-gray-500 hover:text-brown active:text-brown text-2xl font-serif mb-4 md:mb-6" data-view-target="menu" data-action="view#menuClick">書籍</a>
+    <a class="tab not-active text-gray-500 hover:text-brown active:text-brown text-2xl font-serif mb-4 md:mb-6" data-view-target="menu" data-action="view#menuClick">動画</a>
   </div>
 
   <div data-view-target="content" >

--- a/app/views/design_tips/index.html.erb
+++ b/app/views/design_tips/index.html.erb
@@ -3,6 +3,14 @@
   <%= render 'home/search_form' %>
 </div>
 
+<hr class="mt-8">
+<div class="flex" >
+  <% @tag_list.each do|tag| %>
+    <%= link_to tag.name,{:controller=>"design_tips",:action=>"index",:q=>{:tags_name_cont=>tag.name}}, { class: "text-base font-serif text-gray-500 hover:text-emerald-600 m-4" } %>
+  <% end %>
+</div>
+<hr>
+
 <% if params[:q].present? && params[:q][:tags_name_cont].present? %>
   <div class='text-gray-500 text-2xl lg:text-3xl font-serif pt-10'>
     <%= params[:q][:tags_name_cont] %>の情報一覧


### PR DESCRIPTION
## 概要
情報一覧ページのデザインを修正した

## 実装内容
情報一覧ページに各ジャンル別情報ページへのリンクを作成
情報一覧ページのデザインを変更
