### PR TITLE
modify:情報リスト名編集後の画面の遷移先を変更する #237

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -31,7 +31,7 @@ class ListsController < ApplicationController
 
   def update
     if @list.update(list_params)
-      redirect_to @list, success: 'リスト名を変更しました。'
+      redirect_to list_design_tips_path, success: 'リスト名を変更しました。'
     else
       render :edit
     end


### PR DESCRIPTION
## 概要
情報リスト名編集後の画面の遷移先を変更した

## 実装内容
情報リスト名編集後、情報リスト一覧ページへ遷移するように実装
