### PR TITLE
Fix design #239

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,12 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
+
 
 @layer components {
-  .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
+  .btn {
+    @apply  no-animation;
   }
 }
 
-*/
+

--- a/app/views/design_tips/likes.html.erb
+++ b/app/views/design_tips/likes.html.erb
@@ -1,10 +1,15 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 mt-20 pb-16">
-  <% if @like_design_tips.present? %>
-    <%= render @like_design_tips %>
-  <% else %>
-    <p>お気に入り中の情報がありません</p>
-  <% end%>
+<div class='container mx-auto'>
+  <div class='text-gray-600 text-2xl font-serif mb-8 md:mb-12'>
+    お気に入り情報一覧
+  </div>
+  <div class="pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 mt-20 pb-16">
+    <% if @like_design_tips.present? %>
+      <%= render @like_design_tips %>
+    <% else %>
+      <p>お気に入り中の情報がありません</p>
+    <% end%>
+  </div>
 </div>
 
 

--- a/app/views/list_design_tips/index.html.erb
+++ b/app/views/list_design_tips/index.html.erb
@@ -36,7 +36,7 @@
                 <div class='flex gap-2'>
                   <%= render 'design_tips/like_button', design_tip: list_design_tip.design_tip %>
                   <%= link_to list_design_tip_url(list_design_tip), data: { turbo_method: :delete, turbo_confirm: 'リストから削除しますか?' }, status: :see_other do %>
-                    <div class="container text-gray-300 hover:bg-amber-100 rounded-lg flex items-center text-xs">
+                    <div class="container text-gray-300 hover:bg-red-400 rounded-lg flex items-center text-xs">
                       <span class="material-icons">playlist_remove</span>
                       <div>削除</div>
                     </div>

--- a/app/views/list_design_tips/index.html.erb
+++ b/app/views/list_design_tips/index.html.erb
@@ -4,51 +4,56 @@
     <div class='text-gray-600 text-2xl font-serif mb-8 md:mb-12'>
       情報リスト一覧
     </div>
-    <%= link_to new_list_path, class:'btn bg-green-700 hover:bg-green-600 text-white text-xs rounded-lg' do %>
+    <%= link_to new_list_path, class:'btn bg-green-700 hover:bg-green-600 text-white font-serif text-xs rounded-lg' do %>
       <span class="material-icons">playlist_add</span>
       <div>リスト作成</div>
     <% end %>
   </div>
 
-  <% @lists.each do |list| %>
-    <div class="flex gap-8 mt-20 pb-16 items-center font-serif">
-      <div class="text-gray-600 text-2xl"><%= list.name %></div>
-      <%= link_to edit_list_path(list), class: "text-xs text-green-700 hover:text-green-600" do %>
-        <span class="material-icons">mode_edit</span>
-        <div>編集</div>
-      <% end %>
-      <%= button_to list_path(list), method: :delete, form: { data: { turbo_confirm: "リストを削除しますか?" } }, class: "text-xs text-green-700 hover:text-green-600" do %>
-        <span class="material-icons">delete</span>
-        <div>削除</div>
-      <% end %>
-    </div>
-    <% if list.list_design_tips.present? %>
-      <div class="container mx-auto pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 pb-16">
-        <% list.list_design_tips.each do |list_design_tip| %>
-          <div class="bg-white flex md:flex-row rounded-lg shadow-lg">
-            <div class="flex flex-col place-content-between gap-2 p-4 lg:p-6">
-              <div class="text-brown text-xl font-serif hover:text-yellow-900">
-                <%= link_to list_design_tip.design_tip.title, list_design_tip.design_tip.url, target: :_blank, rel: "noopener noreferrer" %>
-              </div>
-              <p class="text-gray-500 text-sm"><%= list_design_tip.design_tip.guidance %></p>
-              <div class="my-5 flex place-content-between">
-                <%= render 'design_tips/tag_list', tag_list: list_design_tip.design_tip.tag_list %>
-                <div class='flex gap-2'>
-                  <%= render 'design_tips/like_button', design_tip: list_design_tip.design_tip %>
-                  <%= link_to list_design_tip_url(list_design_tip), data: { turbo_method: :delete, turbo_confirm: 'リストから削除しますか?' }, status: :see_other do %>
-                    <div class="container text-gray-300 hover:bg-red-400 rounded-lg flex items-center text-xs">
-                      <span class="material-icons">playlist_remove</span>
-                      <div>削除</div>
-                    </div>
-                  <% end %>
+  <% if @lists.present? %>
+    <% @lists.each do |list| %>
+      <div class="flex gap-8 mt-20 pb-16 items-center font-serif">
+        <div class="text-gray-600 text-2xl"><%= list.name %></div>
+        <%= link_to edit_list_path(list), class: "text-xs text-green-700 hover:text-green-600" do %>
+          <span class="material-icons">mode_edit</span>
+          <div>編集</div>
+        <% end %>
+        <%= button_to list_path(list), method: :delete, form: { data: { turbo_confirm: "リストを削除しますか?" } }, class: "text-xs text-green-700 hover:text-green-600" do %>
+          <span class="material-icons">delete</span>
+          <div>削除</div>
+        <% end %>
+      </div>
+      <% if list.list_design_tips.present? %>
+        <div class="container mx-auto pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 pb-16">
+          <% list.list_design_tips.each do |list_design_tip| %>
+            <div class="bg-white flex md:flex-row rounded-lg shadow-lg">
+              <div class="flex flex-col place-content-between gap-2 p-4 lg:p-6">
+                <div class="text-brown text-xl font-serif hover:text-yellow-900">
+                  <%= link_to list_design_tip.design_tip.title, list_design_tip.design_tip.url, target: :_blank, rel: "noopener noreferrer" %>
+                </div>
+                <p class="text-gray-500 text-sm"><%= list_design_tip.design_tip.guidance %></p>
+                <div class="my-5 flex place-content-between">
+                  <%= render 'design_tips/tag_list', tag_list: list_design_tip.design_tip.tag_list %>
+                  <div class='flex gap-2'>
+                    <%= render 'design_tips/like_button', design_tip: list_design_tip.design_tip %>
+                    <%= link_to list_design_tip_url(list_design_tip), data: { turbo_method: :delete, turbo_confirm: 'リストから削除しますか?' }, status: :see_other do %>
+                      <div class="container text-gray-300 hover:bg-red-400 rounded-lg flex items-center text-xs">
+                        <span class="material-icons">playlist_remove</span>
+                        <div>削除</div>
+                      </div>
+                    <% end %>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        <% end %>
-      </div>
-    <% else %>
-      <div class='pb-16'>リストに情報がありません</div>
-    <% end%>
+          <% end %>
+        </div>
+        <hr>
+      <% else %>
+        <div class='text-gray-600 pb-20 font-serif'>リストに情報がありません</div>
+      <% end%>
+    <% end %>
+  <% else %>
+    <div class='text-gray-600 py-20 font-serif'>リストが作成されていません</div>
   <% end %>
 </div>

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -24,7 +24,7 @@
             </div>
 
             <div class="flex items-center justify-center">
-              <%= form.submit class: "btn btn-outline outline-green-800 text-green-800 hover:text-white hover:bg-green-800 rounded-lg" %>
+              <%= form.submit class: "btn bg-green-700 hover:bg-green-600 text-white font-serif text-xs rounded-lg" %>
             </div>
           <% end %>
         </div>

--- a/app/views/lists/new.html.erb
+++ b/app/views/lists/new.html.erb
@@ -24,7 +24,7 @@
             </div>
 
             <div class="flex items-center justify-center">
-              <%= form.submit class: "btn btn-outline outline-green-800 text-green-800 hover:text-white hover:bg-green-800 rounded-lg" %>
+              <%= form.submit '作成する', class: "btn bg-green-700 hover:bg-green-600 text-white font-serif text-xs rounded-lg" %>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
## 概要
デザインの軽微な修正を行った

## 実装内容
お気に入り一覧ページへのページタイトルの追加
リスト削除ボタンのホバーカラーの変更
ボタンのcomponentsにno-animationのスタイルを追加し、アニメーションを解除
ボタンのデザインを統一
リスト一覧ページのデザイン修正とリストが存在しない場合に表示する文言の追加
