### PR TITLE
fix:日本語化対応できていない部分を修正する #241

### DIFF
--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,22 +40,11 @@ ja:
       title: '情報一覧'
       no_result: '情報がありません。'
       to_index: '情報一覧へ'
-    favorites:
-      title: 'お気に入り一覧'
-      no_result: 'お気に入り中の情報がありません。'
   lists:
     edit:
       title: 'リスト名編集'
-  favorites:
-    create:
-      success: 'お気に入りしました'
-    destroy:
-      success: 'お気に入りを外しました'
-  profiles:
-    show:
-      title: 'プロフィール'
-    edit:
-      title: 'プロフィール編集'
+    new:
+      title: 'リスト作成'
   password_resets:
     new:
       title: 'パスワードリセット申請'


### PR DESCRIPTION
## 概要
日本語化対応できていない部分を修正した

## 実装内容
リスト作成画面のタイトルを日本語化対応させた
ja.ymlファイル内の不要なコードを削除した
