### PR TITLE
Add page title #243

### DIFF
--- a/app/views/design_tips/search.html.erb
+++ b/app/views/design_tips/search.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class='container mx-auto flex pt-10'>
   <%= render 'home/search_form' %>
 </div>

--- a/app/views/home/growing.html.erb
+++ b/app/views/home/growing.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class="pb-6 sm:pb-8 lg:pb-12 mt-20">
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
     <div class="font-serif text-gray-600 text-3xl lg:text-4xl py-12">脱・初心者に向けて</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html data-theme="autumn" >
   <head>
-    <title>誰でもデザイン</title>
+    <title><%= content_for?(:title) ? yield(:title) + ' | 誰でもデザイン' : '誰でもデザイン' %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= display_meta_tags(default_meta_tags) %>
     <%= csrf_meta_tags %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,6 +18,13 @@ ja:
       deleted: "%{item}を削除しました"
       delete_confirm: '削除しますか？'
       not_authorized: '権限がありません'
+  home:
+    growing:
+      title: '脱・初心者に向けて'
+    privacy_policy:
+      title: 'プライバシーポリシー'
+    terms_of_use:
+      title: '利用規約'
   users:
     new:
       title: 'ユーザー登録'
@@ -40,11 +47,18 @@ ja:
       title: '情報一覧'
       no_result: '情報がありません。'
       to_index: '情報一覧へ'
+    likes:
+      title: 'お気に入り'
+    search:
+      title: '検索結果'
   lists:
     edit:
       title: 'リスト名編集'
     new:
       title: 'リスト作成'
+  list_design_tips:
+    index:
+      title: 'リスト一覧'
   password_resets:
     new:
       title: 'パスワードリセット申請'


### PR DESCRIPTION
## 概要
各ページに個別のページタイトルを表示させるよう実装した

## 実装内容
個別のタイトルが表示されるようにlayouts/applicationファイルへコードを追加
各ページに個別タイトルが表示できるようコードを追加
ページタイトルの日本語化対応
