### PR TITLE
fix:管理者画面の情報登録ページのデザインを修正する #252

### DIFF
--- a/app/views/admin/design_tips/_form.html.erb
+++ b/app/views/admin/design_tips/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="my-5">
     <%= form.label :title %>
-    <%= form.text_field :title, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.text_area :title, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
   <div class="my-5">
@@ -23,7 +23,7 @@
 
   <div class="my-5">
     <%= form.label :url %>
-    <%= form.text_field :url, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.text_area :url, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
   <div class="my-5">
@@ -33,7 +33,7 @@
 
   <div class="my-5">
     <%= form.label :tag_list %>
-    <%= form.text_field :tag_list, value: @design_tip.tag_list.join(','), placeholder: ",で区切って入力してください", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.text_area :tag_list, value: @design_tip.tag_list.join(','), placeholder: ",で区切って入力してください", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
   <div class="inline">

--- a/app/views/admin/design_tips/new.html.erb
+++ b/app/views/admin/design_tips/new.html.erb
@@ -5,7 +5,7 @@
 
     <div class="my-5">
       <%= form.label :title %>
-      <%= form.text_field :title, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+      <%= form.text_area :title, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">
@@ -15,7 +15,7 @@
 
     <div class="my-5">
       <%= form.label :url %>
-      <%= form.text_field :url, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+      <%= form.text_area :url, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">
@@ -25,7 +25,7 @@
 
     <div class="my-5">
       <%= form.label :tag_list %>
-      <%= form.text_field :tag_list, value: @design_tip.tag_list.join(','), placeholder: ",で区切って入力してください", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+      <%= form.text_area :tag_list, value: @design_tip.tag_list.join(','), placeholder: ",で区切って入力してください", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="inline">


### PR DESCRIPTION
## 概要
管理者画面の情報登録ページのデザインを修正した

## 実装内容
情報登録フォームの入力欄を内容を確認しやすくするために、text_fieldの部分をtext_areaに変更した

