### PR TITLE
fix:リストに情報が登録できないバグを修正する #258

### DIFF
--- a/app/views/design_tips/_list_button.html.erb
+++ b/app/views/design_tips/_list_button.html.erb
@@ -1,22 +1,22 @@
 <div>
-  <label for="my-modal-4" class="container text-gray-300 hover:bg-amber-100 rounded-lg flex items-center text-xs">
+  <label for="my-modal-<%= design_tip.id %>" class="container text-gray-300 hover:bg-amber-100 rounded-lg flex items-center text-xs">
     <span class="material-icons">playlist_add_check</span>
     <div>リスト</div>
   </label>
 </div>
 
-<input type="checkbox" id="my-modal-4" class="modal-toggle" />
+<input type="checkbox" id="my-modal-<%= design_tip.id %>" class="modal-toggle" />
 <div class="modal">
   <div class="bg-white modal-box relative font-serif">
-    <label for="my-modal-4" class="btn btn-sm btn-circle bg-green-800 hover:bg-green-700 text-white absolute right-2 top-2">✕</label>
+    <label for="my-modal-<%= design_tip.id %>" class="btn btn-sm btn-circle bg-green-800 hover:bg-green-700 text-white absolute right-2 top-2">✕</label>
     <h3 class="text-lg my-2">どのリストに追加しますか？</h3>
     <div class="flex justify-center">
       <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
         <div class="p-12 md:p-18">
-          <%= form_tag({controller: "list_design_tips", action: "create", class: 'items-end'})do %>
+          <%= form_with url: {controller: "list_design_tips", action: "create"}, class: 'items-end' do |f| %>
             <%= hidden_field_tag :design_tip_id, design_tip.id %>
-            <%= select_tag :list_id, options_from_collection_for_select(@lists, :id, :name) %>
-            <%= submit_tag "追加する", class: 'badge bg-green-700 hover:bg-green-600 text-white' %>
+            <%= f.select :list_id, options_from_collection_for_select(@lists, :id, :name) %>
+            <%= f.submit "追加する", class: 'badge bg-green-700 hover:bg-green-600 text-white' %>
           <% end %>
           <div class='mt-10'>
             <%= link_to new_list_path, class:'flex justify-center text-gray-400 hover:text-green-800 active:text-green-900' do %>


### PR DESCRIPTION
## 概要
リストに情報が登録できないバグを修正した

## 実装内容
list_buttonが各design_tipに対応したidを持つように実装し、情報がリストに追加されるように修正した

