### PR TITLE
modify:管理者画面の情報一覧ページのN+1問題を解消する #277

### DIFF
--- a/app/controllers/admin/design_tips_controller.rb
+++ b/app/controllers/admin/design_tips_controller.rb
@@ -5,7 +5,7 @@ class Admin::DesignTipsController < Admin::BaseController
   # GET /design_tips or /design_tips.json
   def index
     @q = DesignTip.ransack(params[:q])
-    @design_tips = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page]).per(15)
+    @design_tips = @q.result(distinct: true).preload(:taggings).order(created_at: :desc).page(params[:page]).per(15)
     @tag_list = DesignTip.tag_counts_on(:tags).most_used(20)
   end
 


### PR DESCRIPTION
## 概要
管理者画面の情報一覧ページのN+1問題を解消した

## 実装内容
管理者画面の情報一覧ページのN+1問題解消
