### PR TITLE
fix:Twitterログインができないバグの解消 #301

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -117,7 +117,7 @@ Rails.application.config.sorcery.configure do |config|
   #
   config.twitter.key = Rails.application.credentials.dig(:twitter, :key)
   config.twitter.secret = Rails.application.credentials.dig(:twitter, :secret_key)
-  config.twitter.callback_url = 'http://127.0.0.1:3000/oauth/callback?provider=twitter'
+  config.twitter.callback_url = Settings.sorcery[:twitter_callback_url]
   config.twitter.user_info_mapping = {email: 'screen_name', name: 'name'}
   #
   # config.facebook.key = ""


### PR DESCRIPTION
## 概要
Twitterログインができないバグの解消

## 実装内容
コールバックURLの変更
