### PR TITLE
fix:タグのデザイン崩れの修正 #328

### DIFF
--- a/app/views/list_design_tips/index.html.erb
+++ b/app/views/list_design_tips/index.html.erb
@@ -33,7 +33,7 @@
                 </div>
                 <p class="text-gray-500 text-sm"><%= list_design_tip.design_tip.guidance %></p>
                 <div class="my-5 flex place-content-between">
-                  <%= render 'design_tips/tag_list', tag: list_design_tip.design_tip.tags.pluck(:name) %>
+                  <div class='flex gap-1 md:gap-3'><%= render 'design_tips/tag_list', tag: list_design_tip.design_tip.tags.pluck(:name) %></div>
                   <div class='flex gap-2'>
                     <div class='flex gap-1 md:gap-3'>
                     <%= render 'design_tips/like_button', design_tip: list_design_tip.design_tip %></div>

--- a/app/views/questions/answer.html.erb
+++ b/app/views/questions/answer.html.erb
@@ -20,7 +20,7 @@
           </div>
           <p class="text-gray-500 text-sm"><%= answer_design_tip.design_tip.guidance %></p>
           <div class="my-5 flex place-content-between">
-            <%= render 'design_tips/tag_list', tag: answer_design_tip.design_tip.tags.pluck(:name) %>
+            <div class='flex gap-1 md:gap-3'><%= render 'design_tips/tag_list', tag: answer_design_tip.design_tip.tags.pluck(:name) %></div>
             <% if logged_in? %>
               <%= render 'design_tips/like_button', design_tip: answer_design_tip.design_tip %>
             <% else %>


### PR DESCRIPTION
## 概要
タグのデザイン崩れの修正

## 実装内容
おすすめ情報ページ、情報リストページのタグ欄のデザイン崩れの修正
