### PR TITLE
fix:モーダルが機能していないバグを修正 #351

### DIFF
--- a/app/views/design_tips/_before_login_like.html.erb
+++ b/app/views/design_tips/_before_login_like.html.erb
@@ -1,51 +1,6 @@
-<div>
+<%= link_to new_user_path, data: { turbo_method: :get, turbo_confirm: 'お気に入り機能を利用するにはユーザー登録が必要です。ユーザー登録画面に移動しますか？' } do %>
   <label for="my-modal-3" class="container text-gray-300 hover:bg-pink-50 rounded-lg flex items-center text-xs">
     <svg class="icons-favorite_border"><use xlink:href="#icons-favorite_border"></use></svg>
     <div>お気に入り</div>
   </label>
-</div>
-
-<input type="checkbox" id="my-modal-3" class="modal-toggle" />
-<div class="modal">
-  <div class="bg-white modal-box relative font-serif">
-    <label for="my-modal-3" class="btn btn-sm btn-circle bg-green-800 hover:bg-green-700 text-white absolute right-2 top-2">✕</label>
-    <h3 class="text-lg my-2">お気に入り機能を利用するにはログインが必要です</h3>
-    <div class="flex justify-center">
-      <div class="flex justify-center">
-        <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-          <div class="p-12 md:p-18">
-            <%= form_with url: login_path, local: true do |f| %>
-              <div class="flex flex-col text-lg mb-6 md:mb-8">
-                <%= f.label :email, User.human_attribute_name(:email) %>
-                <%= f.email_field :email, class: "border-none", required: true %>
-              </div>
-              <div class="flex flex-col text-lg mb-6 md:mb-8">
-                <%= f.label :password, User.human_attribute_name(:password) %>
-                <%= f.password_field :password, class: "border-none", required: true %>
-              </div>
-              <div class="flex justify-center">
-                <%= f.submit 'ログイン', class: 'btn bg-green-700 hover:bg-green-600 text-white rounded-lg' %>
-              </div>
-            <% end %>
-            <div class='flex flex-col text-center mt-8'>
-              <div class='flex justify-center'>
-                <%= link_to auth_at_provider_path(provider: :twitter), class: 'flex items-center justify-center text-white bg-blue hover:bg-sky-600 h-10 w-48 rounded' do%>
-                  <svg class="mr-2 -ml-1 w-4 h-4" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="twitter" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M459.4 151.7c.325 4.548 .325 9.097 .325 13.65 0 138.7-105.6 298.6-298.6 298.6-59.45 0-114.7-17.22-161.1-47.11 8.447 .974 16.57 1.299 25.34 1.299 49.06 0 94.21-16.57 130.3-44.83-46.13-.975-84.79-31.19-98.11-72.77 6.498 .974 12.99 1.624 19.82 1.624 9.421 0 18.84-1.3 27.61-3.573-48.08-9.747-84.14-51.98-84.14-102.1v-1.299c13.97 7.797 30.21 12.67 47.43 13.32-28.26-18.84-46.78-51.01-46.78-87.39 0-19.49 5.197-37.36 14.29-52.95 51.65 63.67 129.3 105.3 216.4 109.8-1.624-7.797-2.599-15.92-2.599-24.04 0-57.83 46.78-104.9 104.9-104.9 30.21 0 57.5 12.67 76.67 33.14 23.72-4.548 46.46-13.32 66.6-25.34-7.798 24.37-24.37 44.83-46.13 57.83 21.12-2.273 41.58-8.122 60.43-16.24-14.29 20.79-32.16 39.31-52.63 54.25z"></path></svg>
-                  <div>Twitterログイン</div>
-                <% end %>
-              </div>
-              <br>
-              <%= link_to auth_at_provider_path(provider: :google), class: 'flex justify-center' do%>
-                <%= image_tag "btn_google_signin.jpg", loading: "lazy" %>
-              <% end %>
-              <br>
-              <%= link_to 'ユーザー登録ページへ', new_user_path, class: 'text-gray-400 hover:text-green-800 active:text-green-900'%>
-              <br>
-              <%= link_to 'パスワードをお忘れの方はこちら', new_password_reset_path, class: 'text-gray-400 hover:text-green-800 active:text-green-900'%>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<% end %>


### PR DESCRIPTION
## 概要
モーダルが機能していないバグを修正

## 実装内容
ログイン前お気に入りボタンをクリックするとログインフォームを搭載したモーダルが表示されるように実装していたが
ダイアログが表示されるように変更し、ユーザーが許可すればユーザー登録画面へ遷移できるように修正した。
