### PR TITLE
Fix google login #360

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ gem 'rails_material_design_icons'
 
 gem 'sorcery'
 gem 'config'
-gem 'omniauth-google-oauth2'
 
 gem 'rails-i18n'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,18 +278,6 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    omniauth (2.1.1)
-      hashie (>= 3.4.6)
-      rack (>= 2.2.3)
-      rack-protection
-    omniauth-google-oauth2 (1.1.1)
-      jwt (>= 2.0)
-      oauth2 (~> 2.0.6)
-      omniauth (~> 2.0)
-      omniauth-oauth2 (~> 1.8.0)
-    omniauth-oauth2 (1.8.0)
-      oauth2 (>= 1.4, < 3)
-      omniauth (~> 2.0)
     os (1.1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
@@ -306,8 +294,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.4)
-    rack-protection (3.0.5)
-      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4)
@@ -494,7 +480,6 @@ DEPENDENCIES
   material_icons
   mechanize
   meta-tags
-  omniauth-google-oauth2
   pg (~> 1.1)
   pry-byebug
   puma (~> 5.0)

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -6,25 +6,30 @@ class OauthsController < ApplicationController
   end
 
   def callback
-    provider = params[:provider]
-    if @user = login_from(provider)
+    provider = auth_params[:provider]
+    return redirect_to(root_path, notice: 'ログインをキャンセルしました') if auth_params[:denied].present?
+    @user = login_from(provider)
+    if @user
       redirect_to root_path, success: "#{provider.titleize}アカウントでログインしました"
     else
-      begin
-        @user = create_from(provider)
-
-        reset_session
-        auto_login(@user)
-        redirect_to root_path, success: "#{provider.titleize}アカウントでログインしました"
-      rescue
-        redirect_to root_path, error: "#{provider.titleize}アカウントでログインに失敗しました"
-      end
+      create_user_and_login(provider)
     end
+    rescue ActiveRecord::RecordNotUnique
+      redirect_to root_path, error: "#{provider.titleize}ログインに失敗しました。他の方法でユーザー登録されている可能性があります。"
+    rescue
+      redirect_to root_path, error: "#{provider.titleize}アカウントでのログインに失敗しました"
   end
 
   private
 
   def auth_params
     params.permit(:code, :provider)
+  end
+
+  def create_user_and_login(provider)
+    @user = create_from(provider)
+    reset_session
+    auto_login(@user)
+    redirect_to root_path, success: "#{provider.titleize}アカウントでログインしました"
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,0 @@
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2,
-          Rails.application.credentials.google[:client_id],
-          Rails.application.credentials.google[:client_secret]
-end


### PR DESCRIPTION
## 概要
google loginの修正

## 実装内容
不要なgemomniauth-google-oauth2を削除し、それに関連するファイルを削除した。
oauthコントローラーの例外発生時の処理を修正し、ActiveRecord::RecordNotUniqueエラーが発生した際に
エラー原因をユーザーが把握しやすいようにした。
