### PR TITLE
add:お気に入りをもとにおすすめの情報を表示させる機能を実装 #381

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,8 @@ class HomeController < ApplicationController
     @q = DesignTip.ransack(params[:q])
     @design_tips = @q.result(distinct: true).preload(:reviews)
     @sort_design_tips = DesignTip.preload(:reviews).sort_by_average_score
+    return unless current_user
+    @recommend_design_tips = DesignTip.recommended_for(current_user)
   end
 
   def for_beginner

--- a/app/models/design_tip.rb
+++ b/app/models/design_tip.rb
@@ -33,4 +33,10 @@ class DesignTip < ApplicationRecord
     DesignTip.all.sort_by { |tip| -tip.average_score(tip.id) }
   end
 
+  def self.recommended_for(user)
+    user_likes = user.likes
+    design_tip_ids = user_likes.pluck(:design_tip_id)
+    tag_names = DesignTip.tag_counts_on(:tags).where(id: design_tip_ids).pluck(:name)
+    DesignTip.tagged_with(tag_names, any: true).where.not(id: design_tip_ids).distinct
+  end
 end

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -32,6 +32,19 @@
   </div>
 </div>
 
+<% if logged_in? %>
+  <div class='text-brown text-lg md:text-xl lg:text-3xl font-serif text-center mb-4 md:mb-6'>あなたにおすすめの情報</div>
+  <% if @recommend_design_tips.present? %>
+    <div class="container mx-auto pt-3 grid sm:grid-cols-2 xl:grid-cols-3 gap-8 md:gap-12 xl:gap-16 mt-20 pb-16">
+      <% @recommend_design_tips.take(3).each do |design_tip| %>
+        <%= render 'design_tips/design_tip', design_tip: design_tip %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class='text-center text-gray-600 pb-20 font-serif'>お気に入り登録された情報がありません。情報をお気に入りしていただくと、<br>そちらをもとにあなたにおすすめの情報を表示します。</div>
+  <% end %>
+<% end %>
+
 <div class="bg-gray pt-36 pb-12 lg:py-48 mt-2 md:mt-80 lg:mt-2">
   <div class="px-4 md:px-8">
     <div data-controller="view">


### PR DESCRIPTION
## 概要
お気に入りをもとにおすすめの情報を表示させる機能を実装

## 実装内容
ログイン後のトップページにお気に入りをもとにおすすめの情報を表示させる機能を実装
お気に入りした情報と同じタグの情報で、まだお気に入りしていない情報を表示するようにした