### PR TITLE
Add search autocomplete #389

### DIFF
--- a/app/controllers/design_tips_controller.rb
+++ b/app/controllers/design_tips_controller.rb
@@ -4,6 +4,7 @@ class DesignTipsController < ApplicationController
   skip_before_action :require_login
 
   def index
+    @search_design_tips = DesignTip.all
     @design_tips = @q.result(distinct: true).preload(:tags, :reviews)
     @tag_list = DesignTip.tag_counts_on(:tags).most_used(20)
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,9 @@
 class HomeController < ApplicationController
   skip_before_action :require_login
+  before_action :set_q, only: :top
 
   def top
-    @q = DesignTip.ransack(params[:q])
-    @design_tips = @q.result(distinct: true).preload(:reviews)
+    @search_design_tips = DesignTip.all
     @sort_design_tips = DesignTip.preload(:reviews).sort_by_average_score
     return unless current_user
     @recommend_design_tips = DesignTip.recommended_for(current_user)
@@ -22,5 +22,11 @@ class HomeController < ApplicationController
   end
 
   def operation
+  end
+
+  private
+
+  def set_q
+    @q = DesignTip.ransack(params[:q])
   end
 end

--- a/app/views/home/_search_form.html.erb
+++ b/app/views/home/_search_form.html.erb
@@ -1,5 +1,10 @@
 <%= search_form_for @q, url: search_design_tips_path, class: 'flex items-center gap-2 font-serif' do |f| %>
-  <%= f.search_field :title_cont, class: "w-44 md:w-48 md:w-64 h-12 outline-green-800 rounded-lg", placeholder: 'フリーワード検索', required: true %>
+  <%= f.search_field :title_cont, class: "w-44 md:w-48 md:w-64 h-12 outline-green-800 rounded-lg", placeholder: 'タイトル検索', autocomplete: "on", list: "titles", required: true %>
+  <datalist id="titles">
+    <% @search_design_tips.each do |design_tip| %>
+      <option value="<%= "#{design_tip.title}" %>"></option>
+    <% end %>
+  </datalist>
   <button class="btn bg-green-700 hover:bg-green-600 text-white rounded-lg hidden md:inline-block">
     <div class='flex items-center'>
       <svg class="icons"><use xlink:href="#icons-search"></use></svg>


### PR DESCRIPTION
## 概要
検索のオートコンプリート機能の実装

## 実装内容
検索フォームのパーシャルのautocomplete属性をonにしてオートコンプリートを有効化
検索を利用できるページで検索に必要な情報をインスタンス変数に定義し、検索フォームのパーシャルの
datalist内で受け取る
