### PR TITLE
fix:検索ができないバグの修正 #391

### DIFF
--- a/app/controllers/design_tips_controller.rb
+++ b/app/controllers/design_tips_controller.rb
@@ -15,6 +15,7 @@ class DesignTipsController < ApplicationController
   end
 
   def search
+    @search_design_tips = DesignTip.all.preload(:reviews)
     @results = @q.result
     @tag_list = DesignTip.tag_counts_on(:tags).most_used(20)
   end


### PR DESCRIPTION
## 概要
検索ができないバグの修正

## 実装内容
必要なインスタンス変数が定義できていなかったため修正
