### PR TITLE
fix:お気に入りを元にしたレコメンド機能のバグ修正 #398

### DIFF
--- a/app/models/design_tip.rb
+++ b/app/models/design_tip.rb
@@ -35,9 +35,8 @@ class DesignTip < ApplicationRecord
   end
 
   def self.recommended_for(user)
-    user_likes = user.likes
-    design_tip_ids = user_likes.pluck(:design_tip_id)
-    tag_names = DesignTip.tag_counts_on(:tags).where(id: design_tip_ids).pluck(:name)
+    design_tip_ids = user.likes.pluck(:design_tip_id)
+    tag_names = ActsAsTaggableOn::Tag.joins(:taggings).where(taggings: { taggable_type: 'DesignTip', taggable_id: design_tip_ids }).pluck(:name)
     DesignTip.tagged_with(tag_names, any: true).where.not(id: design_tip_ids).distinct
   end
 


### PR DESCRIPTION
## 概要
お気に入りを元にしたレコメンド機能のバグ修正

## 実装内容
表示される情報が想定と異なっていっため修正
tag_idを抽出するべきところをdesign_tip_idを抽出してしまっていたことが原因だったためそれを修正した。

