### PR TITLE
add:カラー抽出ページのフォームにバリデーションを設定 #467

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,18 +4,26 @@ class ImagesController < ApplicationController
   def index
     @query = params[:query]
     @images = PixabayApi.search_images(@query)
+    new
   end
 
   def create
-    image_file = params[:image]
-    image_path = image_file.tempfile.path
-    @colors = get_image_colors(image_path)
-    query = params[:query]
-    @images = PixabayApi.search_images(query)
-    render :index
+    @image_restriction = ImageRestriction.new(image: params[:image_restriction][:image])
+    if @image_restriction.valid?
+      image_file = params[:image_restriction][:image]
+      image_path = image_file.tempfile.path
+      @colors = get_image_colors(image_path)
+      query = params[:query]
+      @images = PixabayApi.search_images(query)
+      render :index
+    else
+      render :index
+    end
   end
 
-  private
+  def new
+    @image_restriction = ImageRestriction.new
+  end
 
   def get_image_colors(image_path)
     require "google/cloud/vision"

--- a/app/models/image_restriction.rb
+++ b/app/models/image_restriction.rb
@@ -1,0 +1,20 @@
+class ImageRestriction
+  include ActiveModel::Model
+
+  attr_accessor :image
+
+  validates :image, presence: true
+  validate :acceptable_image
+
+  def acceptable_image
+    return unless image
+
+    if image.size > 5.megabytes
+      errors.add(:image, "※5MB以下の画像を選択してください")
+    end
+
+    unless image.content_type.in?(%('image/jpeg image/png'))
+      errors.add(:image, "※条件に合う形式の画像を選択してください")
+    end
+  end
+end

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -12,10 +12,20 @@
 
 <%= turbo_frame_tag "color" do %>
   <div class='container mx-auto'>
+    <div class='text-gray-600'>条件：jpeg(jpg)またはpng形式で5MB以下</div>
     <div class='flex'>
-      <%= form_with(url: images_path, data: { turbo_frame: 'color' }, remote: true, multipart: true) do |form| %>
+      <%= form_with(model: @image_restriction, url: images_path, data: { turbo_frame: 'color' }, remote: true, multipart: true) do |form| %>
         <div class='flex gap-1 font-serif'>
-          <%= form.file_field :image, required: true, class: 'file-input file-input-ghost w-full max-w-xs border border-gray-500 bg-white' %>
+          <div class='flex flex-col'>
+            <%= form.file_field :image, required: true, class: 'file-input file-input-ghost w-full max-w-xs border border-gray-500 bg-white' %>
+            <% if @image_restriction.errors[:image].any? %>
+              <div class="error-message">
+                <% @image_restriction.errors[:image].each do |message| %>
+                  <p class='text-red-500'><%= message %></p>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
           <%= form.submit "カラー抽出を行う", class: 'btn bg-green-700 hover:bg-green-600 text-white font-serif rounded-lg' %>
         </div>
       <% end %>


### PR DESCRIPTION
## 概要
カラー抽出ページのフォームにバリデーションを設定

## 実装内容
カラー抽出ページのフォームにファイル形式と画像サイズでバリデーションがかかるように設定
